### PR TITLE
Fix for exiting the application.

### DIFF
--- a/BattLab_One_V1.0.6.py
+++ b/BattLab_One_V1.0.6.py
@@ -589,7 +589,7 @@ filemenu.add_command(label='Open', command=OpenFile)
 filemenu.add_command(label='Save', command=SaveFile, state=DISABLED)
 filemenu.add_command(label='Export', command=export_data, state=DISABLED)
 filemenu.add_separator()
-filemenu.add_command(label='Exit', command=quitapp)
+filemenu.add_command(label='Exit', command=lambda arg=root:quitapp(arg))
 
 optionsmenu = Menu(menu)
 menu.add_cascade(label='Options', menu=optionsmenu)

--- a/BattLab_One_V1.0.6.py
+++ b/BattLab_One_V1.0.6.py
@@ -565,24 +565,17 @@ def Disclaimer():
              EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.')
 
 
-def quitapp():
-
-   u = tk.IntVar()
-   u=0
-    
+def quitapp(window):
    if messagebox.askokcancel("Quit", "Do you want to quit?"):
       try:
          cmd = 'i'
          bytes_returned = ser.write(cmd.encode())
          ser.close()
-         root.destroy()
       except:
-         root.destroy()
          pass
-      
-   else:
-      u=u+1 #Do nothing     
-   
+      window.quit()
+
+
 #################################################################################
 ###   SETUP MENU SYSTEM
 #################################################################################
@@ -1800,6 +1793,6 @@ data_plot(x,y,str(0),str(0),str(0),str(0),str(0))
 #cmd = 'i' #turn voltage off
 #bytes_returned = ser.write(cmd.encode())
 
-root.protocol("WM_DELETE_WINDOW", quitapp)
-   
+root.protocol("WM_DELETE_WINDOW", lambda arg=root: quitapp(arg))
 root.mainloop()
+


### PR DESCRIPTION
The root window was destroyed, but the mainloop was still running. By using quit() the mainloop will terminate and the program will exit.