### PR TITLE
More reliable way to get device name

### DIFF
--- a/BattLab_One_V1_0_9.py
+++ b/BattLab_One_V1_0_9.py
@@ -392,7 +392,7 @@ for p in ports:
    if p.vid == 0x0403 and p.pid == 0x6001:
       ser_num_prefix = p.serial_number[0] + p.serial_number[1]
       if ser_num_prefix == 'BB':
-         com_port = list(list_ports.grep("0403:6001"))[0][0]       
+         com_port = p.device
          init(com_port)
 
 if com_port == 'NONE':


### PR DESCRIPTION
The grep doesn't always select the correct entry in list_ports if there are multiple with the same VID:PID.
Only verified to work on Windows, but I'd expect pyserial device name handling to be pretty cross platform.